### PR TITLE
Add MuJoCo to simulator list and include mujoco-scene-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ that are physically accurate, photo realistic, or roboticist friendly.
 - [LIBERO](https://github.com/Lifelong-Robot-Learning/LIBERO) - Benchmarking Knowledge Transfer in Lifelong Robot Learning
 - [MetaDrive](https://github.com/metadriverse/metadrive/) -  Open-source Driving Simulator for AI and Autonomy Research
 - [MORSE](http://morse-simulator.github.io/) - The open-source simulator for academic robotics
+- [MuJoCo](https://mujoco.org/) - Advanced physics simulation
 - [NVIDIA Isaac Sim](https://developer.nvidia.com/isaac-sim) - Simulate, test and iterate virtual robots in a high fidelity 3D environment
 - [OmniGibson](https://github.com/StanfordVL/OmniGibson) - A platform for accelerating Embodied AI research built upon NVIDIA's Omniverse engine
 - [Open 3D Engine (O3DE)](https://github.com/o3de/o3de) - An Apache 2.0-licensed multi-platform 3D engine that enables developers and content creators to build AAA games, cinema-quality 3D worlds, and high-fidelity simulations without any fees or commercial obligations.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A list of open-source, affordable, less-known, or visionary robotics projects ..
 - [AR.js](https://ar-js-org.github.io/AR.js-Docs/) - Augmented Reality on the Web
 - [CloudPeek](https://github.com/Geekgineer/CloudPeek/tree/main) - Lightweight, cross-platform, single-header C++ point cloud viewer
 - [Lanelet2](https://github.com/fzi-forschungszentrum-informatik/lanelet2) - C++ library for handling map data in the context of automated driving
+- [mujoco-scene-editor](https://github.com/markusgrotz/mujoco-scene-editor) - Lightweight, interactive scene editor for MuJoCo scenes
 - [Realtime robot data visualization in the browser](https://github.com/rapyuta-robotics/zethus/)
 - [rerun.io](https://www.rerun.io/) - Open source visualization infrastructure for computer vision and robotics
 - [ROS Reality](https://github.com/h2r/ros_reality) - Connect a ROS-enabled robot to Unity


### PR DESCRIPTION
This PR adds MuJoCo to the simulator list and includes mujoco-scene-editor in the resources section.