### PR TITLE
Add GrabaRobot to Robotics Tooling Companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ that are physically accurate, photo realistic, or roboticist friendly.
 - [Formant](https://formant.io/) - Speak Robot; Intelligent platform for robotic fleets
 - [Freedom robotics](https://www.freedomrobotics.ai/) - POWERFUL CONTROL AND MONITORING FOR ROBOTS
 - [Generalist](https://generalistai.com/)
+- [GrabaRobot](https://www.grabarobot.com/) - Compare 500+ robots across 27 categories from Chinese and global manufacturers. Free ROI calculator, pricing index, and side-by-side comparison tool.
 - [Honu Robotics](https://honurobotics.com/) - Expert partners for your next innovation
 - [InOrbit](https://www.inorbit.ai/) - MISSION CONTROL for AUTONOMOUS ROBOTS
 - [KABAM Robotics](https://kabam.ai/) - WORK MANAGEMENT SYSTEM FOR ALL YOUR ROBOTS & SMART DEVICES


### PR DESCRIPTION
## What is GrabaRobot?

[GrabaRobot](https://www.grabarobot.com/) is a free robot comparison and sourcing platform with tools for evaluating automation investments.

**Features:**
- **500+ robots** across **27 categories** (welding, palletizing, warehouse AMR, drones, humanoid robots, etc.)
- **[ROI Calculator](https://www.grabarobot.com/tools/robot-roi-calculator/)** - estimate payback period and 5-year savings
- **[Comparison Tool](https://www.grabarobot.com/tools/robot-comparison/)** - compare specs and prices side by side
- **[Pricing Index](https://www.grabarobot.com/reports/robot-pricing-index/)** - average prices for all 27 categories
- Covers Chinese manufacturers (Estun, AUBO, DJI) and global brands (FANUC, ABB, KUKA)

Added under **Robotics Tooling Companies** as it provides tooling for robot selection and procurement.
