### PR TITLE
Add Rose Mk2 (autonomous river/sea drifter boat) to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A list of open-source, affordable, less-known, or visionary robotics projects ..
 - [RoboPrime](https://github.com/simonepri/roboprime) - Full featured 21 DOF 3D Printed Humanoid Robot based on ATmega328P chip
 - [Robotics Middleware Framework](https://github.com/osrf/rmf_demos) - Task queuing, conflict-free resource scheduling, utilities to help create robot fleet adapters, and so on
 - [ROSbot 2.0](https://husarion.com/) - Open source mobile robot platform
+- [Rose Mk2](https://j4zz.eu/rose-mk2/) - Self-righting hull designed to drift river current and tidal gating unpowered from Bonn to the North Sea; CAD stage, not yet built.
 - [RUKA](https://ruka-hand.github.io/) - Rethinking the Design of Humanoid Hands with Learning
 - [Stanford Doggo](https://github.com/Nate711/StanfordDoggoProject) - Open-source quadruped robot
 - [Thor](https://hackaday.io/project/12989-thor) - DIY 3D printable robotic arm


### PR DESCRIPTION
Adds Rose Mk2, an autonomous river/sea current-riding drifter boat, to the main project list.

It's a 1.2 m self-righting keel-ballasted hull designed to drift unpowered from Bonn down the Rhine/Waal/Nieuwe Waterweg to the open North Sea, using river current for most of the route and tide-gated anchoring (folding anchor + nichrome burn-wire release) for the final tidal stretch. Full build plan (physics, BOM, verification) at the linked page.

Note: this is currently a CAD-stage design (parametric hull optimizer + generated mesh), not yet physically built — flagged as such in the added description, in keeping with the list's inclusion of visionary/less-known projects alongside built ones (e.g. the existing Just1 entry, which is also a personal write-up rather than a repo).